### PR TITLE
Add stub.callOriginal() that configures a stub to call the unstubbed function

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ simple.mock(obj, 'example').returnWith('etc') // Stub
 simple.mock(obj, 'example').throwWith(new Error()) // Stub
 simple.mock(obj, 'example').resolveWith('etc') // Stub
 simple.mock(obj, 'example').rejectWith(new Error()) // Stub
+simple.mock(obj, 'example').callOriginal() // Unstubbed call
 ```
 
 Then, to make sure all objects are back to the state the were in before your mocks:
@@ -160,6 +161,11 @@ Resets all counts and properties to the original state.
 ### stub.callFn(fn)
 
 Configures this stub to call this function, returning its return value. Subsequent calls of this on the same stub (chainable) will queue up different behaviours for each subsequent call of the stub.
+
+### stub.callOriginal()
+
+Configures this stub to call the original, unstubbed function, returning its return value. Subsequent calls of this on the same stub (chainable) will queue up different behaviours for each subsequent call of the stub.
+
 
 ### stub.returnWith(val)
 

--- a/index.js
+++ b/index.js
@@ -61,6 +61,8 @@
       wrappedFn = wrappedFn[key]
     }
 
+    var originalFn = wrappedFn
+
     var stubFn = function () {
       var action = (newFn.loop) ? newFn.actions[(newFn.callCount - 1) % newFn.actions.length] : newFn.actions.shift()
 
@@ -159,6 +161,12 @@
     newFn.callFn = function (fn) {
       wrappedFn = stubFn
       newFn.actions.push({ fn: fn })
+      return newFn // Chainable
+    }
+
+    newFn.callOriginal = newFn.callOriginalFn = function () {
+      wrappedFn = stubFn
+      newFn.actions.push({ fn: originalFn })
       return newFn // Chainable
     }
     return newFn

--- a/test.js
+++ b/test.js
@@ -891,6 +891,16 @@ describe('simple', function () {
         simple.restore()
         assert.equal(obj.protoFn(), 'x')
       })
+
+      it('can mock with stubbed functions and prototype\'s original over its prototype\'s and restore', function () {
+        simple.mock(obj, 'protoFn').returnWith('y').callOriginal().returnWith('z')
+        assert.equal(obj.protoFn(), 'y')
+        assert.equal(obj.protoFn(), 'x')
+        assert.equal(obj.protoFn(), 'z')
+        assert.equal(obj.protoFn.callCount, 3)
+        simple.restore()
+        assert.equal(obj.protoFn(), 'x')
+      })
     })
 
     describe('on an anonymous object', function () {


### PR DESCRIPTION
This PR adds `stub.callOriginal()` that configures a stub to call the original unstubbed function.

Can be useful for example if you want the stubbed function to throw an error the first time it's called and succeed the second time.

``` javascript
simple.mock(obj, 'example').throwWith(new Error()).callOriginal()
```

I also added `callOriginalFn` as an alias for `callOriginal`(to be similar to `callFn` that ends in `Fn`)

##### Discussion
Unsure about the name "`callOriginal`". Maybe you have a better suggestion. 