### PR TITLE
Add loop toggle functions for stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,10 @@ Configures the stub to return a Promise (where available] resolving to this valu
 
 Configures the stub to return a Promise (where available) rejecting with this error. Same as `stub.returnWith(Promise.reject(val))`. You can use a custom Promise-conforming library, i.e. `simple.Promise = require('bluebird')` or `simple.Promise = $q`.
 
+### stub.withLoop & stub.noLoop
+
+Configures the stub to enable/disable [looping](#stubloop).
+
 ### stub.actions
 
 An array of behaviours, each having *one* of these properties:

--- a/index.js
+++ b/index.js
@@ -183,6 +183,16 @@
       newFn.actions.push({ fn: originalFn })
       return newFn // Chainable
     }
+
+    newFn.withLoop = function () {
+      newFn.loop = true
+      return newFn // Chainable
+    }
+
+    newFn.noLoop = function () {
+      newFn.loop = false
+      return newFn // Chainable
+    }
     return newFn
   }
 

--- a/test.js
+++ b/test.js
@@ -866,6 +866,33 @@ describe('simple', function () {
         })
       })
     })
+
+    describe('#noLoop', function () {
+
+      it('should disable looping', function () {
+
+        var stub = simple.stub().noLoop().returnWith('foo')
+
+        assert.equal(stub(), 'foo')
+        assert.equal(stub(), undefined)
+
+      })
+
+    })
+
+    describe('#withLoop', function () {
+
+      it('should enable looping', function () {
+
+        var stub = simple.stub().withLoop().returnWith('foo')
+
+        assert.equal(stub(), 'foo')
+        assert.equal(stub(), 'foo')
+
+      })
+
+    })
+
   })
 
   describe('restore()', function () {


### PR DESCRIPTION
Add stub.withLoop and stub.noLoop which respectively set stub.loop to true or false. Allows changing loop behavior with chainable calls. Closes #15.
