### PR TITLE
Revert "Change docs: reset => restore", PR #19

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ An array of calls, each having these properties:
 
 The last call object, with properties as above. (This is often also the first and only call.)
 
-### spy.restore()
+### spy.reset()
 
 Resets all counts and properties to the original state.
 


### PR DESCRIPTION
Reverts PR #19. I mixed up `spy.reset` with `simple.restore`. Sorry about that!
 
This reverts commit 5f99406366f89b7e4a444ef944789016e783336c.