### PR TITLE
Mark `mockedValue` as optional.

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@
    *
    * @param {Object} obj
    * @param {String} key
-   * @param {Function|Value} mockValue
+   * @param {Function|Value} [mockValue]
    * @return {Function} mock
    * @api public
    */


### PR DESCRIPTION
Since a [mockedValue] is not required, when the mock is being treated as purely a spy. Without this IDEs complain that a required param isn't being passed in. Webstorm has already shown this behavior.