### PR TITLE
Create rejectWith Promises when mock is called

### DIFF
--- a/index.js
+++ b/index.js
@@ -169,7 +169,7 @@
     }
 
     newFn.rejectWith = function (value) {
-      return newFn.returnWith(simple.Promise.reject(value))
+      return newFn.callFn(function createRejectedPromise () { return simple.Promise.reject(value) })
     }
 
     newFn.callFn = function (fn) {

--- a/index.js
+++ b/index.js
@@ -164,8 +164,8 @@
     }
 
     newFn.resolveWith = function (value) {
-      if (simple.Promise.when) return newFn.returnWith(simple.Promise.when(value))
-      return newFn.returnWith(simple.Promise.resolve(value))
+      if (simple.Promise.when) return newFn.callFn(function createResolvedPromise () { return simple.Promise.when(value) })
+      return newFn.callFn(function createResolvedPromise () { return simple.Promise.resolve(value) })
     }
 
     newFn.rejectWith = function (value) {

--- a/test.js
+++ b/test.js
@@ -749,6 +749,10 @@ describe('simple', function () {
         })
       })
 
+      afterEach(function () {
+        simple.restore()
+      })
+
       describe('with a single resolving configuration', function () {
         beforeEach(function () {
           stubFn = simple.stub().resolveWith('example')

--- a/test.js
+++ b/test.js
@@ -994,6 +994,34 @@ describe('simple', function () {
       })
     })
 
+    describe('when mock rejectsWith', function () {
+
+      it('and mock is called at a later time then no UnhandledPromiseRejectionWarning and PromiseRejectionHandledWarning occurs', function (done) {
+        var warnings = []
+        function logWarning () {
+          var message = arguments.length === 2 ? 'Unhandled promise rejection' : 'Promise rejection was handled asynchronously'
+          warnings.push(message)
+        }
+        process.on('rejectionHandled', logWarning)
+        process.on('unhandledRejection', logWarning)
+
+        var mock = simple.mock().rejectWith(new Error('from rejectWith'))
+        setTimeout(function () {
+          mock().then(function () {
+            return Promise.reject('Mock should have been rejected')
+          }, function () {
+            assert.equal(warnings.length, 0, 'Warnings "' + warnings.join('", "') + '"')
+          })
+          .then(done, done)
+          .then(function () {
+            process.removeListener('rejectionHandled', logWarning)
+            process.removeListener('unhandledRejection', logWarning)
+          })
+        })
+      })
+
+    })
+
     describe('#noLoop', function () {
 
       it('should disable looping', function () {


### PR DESCRIPTION
Fixes #22

Since node 6.9, if a promise is rejected and no error handler is attached to the promise within a turn of the event loop, or if an error handler was attached to it later than one turn of the Node.js event loop, then warnings are logged (and in future versions of node it will terminate the node process).

Since `rejectWith` creates the promise when _it_ is called, and __not__ when _the mock_ is called, this means that the following code will generate warnings:

``` js
const mock = simple.mock().rejectWith(new Error())
setTimeout(() => mock().then( () =>..., err => ...), 0)
```

This PR demonstrates this by first adding a test, and then fixes it by create the rejected promise when the mock is called.