### PR TITLE
Allow any values for mockValue

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@
    *
    * @param {Object} obj
    * @param {String} key
-   * @param {Function|Value} mockValue
+   * @param {Function|*} mockValue
    * @return {Function} mock
    * @api public
    */


### PR DESCRIPTION
At this moment by JSDoc allowed only Function or Value in "mockValue" argument. Better if JSDoc-rule will be looks like "Function|*", because we can mock object properties.